### PR TITLE
Implementation of consistent extensive API to control configuration

### DIFF
--- a/packages/client/src/configuration/configuration-repository.ts
+++ b/packages/client/src/configuration/configuration-repository.ts
@@ -13,7 +13,7 @@ declare global {
     var __qsMagellanConfig__: Configuration;
 }
 
-export const initProjectConfiguration = (projectConfiguration: Configuration): Configuration => {
+export const initProjectConfiguration = (projectConfiguration: Partial<Configuration>): Configuration => {
     return persistConfig(expandConfig(projectConfiguration));
 };
 
@@ -21,7 +21,7 @@ export const getConfiguration = (): Configuration => {
     return global.__qsMagellanConfig__ ?? persistConfig(expandConfig(getDefaultConfiguration()));
 };
 
-const expandConfig = (configuration: Configuration | undefined): Configuration => {
+const expandConfig = (configuration: Partial<Configuration> | undefined): Configuration => {
     return {
         ...getDefaultConfiguration(),
         ...configuration,

--- a/packages/client/src/configuration/index.ts
+++ b/packages/client/src/configuration/index.ts
@@ -4,8 +4,8 @@
  *   Licensed under the MIT License. See LICENSE in the project root for license information.
  * ---------------------------------------------------------------------------------------------
  */
-export type {TransportHandler, NamespaceMapping, Configuration} from "./Configuration";
-export type {Context} from "./Context";
-export {initProjectConfiguration, getConfiguration} from "./configuration-repository";
-export {addNamespace, addTransport, resolveNamespace} from "./namespace";
-export type {ResolvedNamespace} from "./ResolvedNamespace";
+export type { Configuration, NamespaceMapping, TransportHandler } from "./Configuration";
+export { getConfiguration, initProjectConfiguration } from "./configuration-repository";
+export type { Context } from "./Context";
+export { addNamespace, addNamespaceIfAbsent, addTransport, addTransportIfAbsent, resolveNamespace, setNamespace, setTransport } from "./namespace";
+export type { ResolvedNamespace } from "./ResolvedNamespace";

--- a/packages/client/src/configuration/namespace.spec.ts
+++ b/packages/client/src/configuration/namespace.spec.ts
@@ -1,0 +1,132 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
+import { getConfiguration, initProjectConfiguration } from "./configuration-repository";
+import { addNamespace, addNamespaceIfAbsent, addTransport, addTransportIfAbsent, setNamespace, setTransport } from "./namespace";
+
+const defaultTransport = jest.fn();
+
+beforeEach(() => {
+    initProjectConfiguration({ namespaces: { default: { endpoint: "/api", transport: "default" } }, transports: { default: defaultTransport } });
+});
+
+describe("addNamespace", () => {
+    it("should add namespace if it does not exist", () => {
+        const expected = { endpoint: "/expected", transport: "expected" };
+
+        addNamespace("expected", expected);
+
+        expect(getConfiguration().namespaces).toEqual({
+            default: { endpoint: "/api", transport: "default" },
+            expected: expected,
+        });
+    });
+
+    it("should throw error when namespace is added that already exists", () => {
+        expect(() => addNamespace("default", { endpoint: "/expected", transport: "expected" })).toThrow(
+            new Error('Namespace "default" already registered.')
+        );
+    });
+});
+
+describe("addNamespaceIfAbsent", () => {
+    it("should add namespace if it does not exist", () => {
+        const expected = { endpoint: "/expected", transport: "expected" };
+
+        addNamespaceIfAbsent("expected", expected);
+
+        expect(getConfiguration().namespaces).toEqual({
+            default: { endpoint: "/api", transport: "default" },
+            expected: expected,
+        });
+    });
+
+    it("should not add or alter namespace if it exists", () => {
+        addNamespaceIfAbsent("default", { endpoint: "/expected", transport: "expected" });
+
+        expect(getConfiguration().namespaces).toEqual({ default: { endpoint: "/api", transport: "default" } });
+    });
+});
+
+describe("setNamespace", () => {
+    it("should replace the default namespace", () => {
+        const expected = { endpoint: "/expected", transport: "expected" };
+
+        setNamespace("default", expected);
+
+        expect(getConfiguration().namespaces).toEqual({ default: expected });
+    });
+
+    it("should add namespace if it does not exist", () => {
+        const expected = { endpoint: "/expected", transport: "expected" };
+
+        setNamespace("expected", expected);
+
+        expect(getConfiguration().namespaces).toEqual({
+            default: { endpoint: "/api", transport: "default" },
+            expected: expected,
+        });
+    });
+});
+
+describe("addTransport", () => {
+    it("should add transport if it does not exist", () => {
+        const expected = jest.fn();
+
+        addTransport("expected", expected);
+
+        expect(getConfiguration().transports).toEqual({
+            default: defaultTransport,
+            expected: expected,
+        });
+    });
+
+    it("should throw error when transport is added that already exists", () => {
+        expect(() => addTransport("default", jest.fn())).toThrow(new Error('Transport "default" already registered.'));
+    });
+});
+
+describe("addTransportIfAbsent", () => {
+    it("should add transport if it does not exist", () => {
+        const expected = jest.fn();
+
+        addTransportIfAbsent("expected", expected);
+
+        expect(getConfiguration().transports).toEqual({
+            default: defaultTransport,
+            expected: expected,
+        });
+    });
+
+    it("should not add or alter transport if it exists", () => {
+        const target = jest.fn();
+
+        addTransportIfAbsent("default", target);
+
+        expect(getConfiguration().transports).toEqual({ default: defaultTransport });
+    });
+});
+
+describe("setTransport", () => {
+    it("should replace the default transport", () => {
+        const expected = jest.fn();
+
+        setTransport("default", expected);
+
+        expect(getConfiguration().transports).toEqual({ default: expected });
+    });
+
+    it("should add transport if it does not exist", () => {
+        const expected = jest.fn();
+
+        setTransport("expected", expected);
+
+        expect(getConfiguration().transports).toEqual({
+            default: defaultTransport,
+            expected: expected,
+        });
+    });
+});

--- a/packages/client/src/configuration/namespace.ts
+++ b/packages/client/src/configuration/namespace.ts
@@ -12,15 +12,42 @@ import { ResolvedNamespace } from "./ResolvedNamespace";
 
 export const addNamespace = (namespace: string, mapping: NamespaceMapping): void | never => {
     const config = getConfiguration();
-    assert(!config.namespaces[namespace], `Namespace ${namespace} already registered.`);
+    assert(!config.namespaces[namespace], `Namespace "${namespace}" already registered.`);
+    config.namespaces[namespace] = mapping;
+};
+
+export const addNamespaceIfAbsent = (namespace: string, mapping: NamespaceMapping): void => {
+    const config = getConfiguration();
+    if (!config.namespaces[namespace]) {
+        config.namespaces[namespace] = mapping;
+    }
+};
+
+export const setNamespace = (namespace: string, mapping: NamespaceMapping): void => {
+    const config = getConfiguration();
     config.namespaces[namespace] = mapping;
 };
 
 export const addTransport = (name: string, handler: TransportHandler): void | never => {
     const config = getConfiguration();
     config.transports = config.transports || {};
-    assert(!config.transports?.[name], `Transport ${name} already registered.`);
+    assert(!config.transports[name], `Transport "${name}" already registered.`);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    config.transports[name] = handler;
+};
+
+export const addTransportIfAbsent = (name: string, handler: TransportHandler): void => {
+    const config = getConfiguration();
+    config.transports = config.transports || {};
+    if (!config.transports[name]) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        config.transports[name] = handler;
+    }
+};
+
+export const setTransport = (name: string, handler: TransportHandler): void => {
+    const config = getConfiguration();
+    config.transports = config.transports || {};
     config.transports[name] = handler;
 };
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -6,8 +6,32 @@
  */
 
 import { deserialize, serialize } from "@quatico/magellan-shared";
+import type { Configuration, Context, NamespaceMapping, TransportHandler } from "./configuration";
+import {
+    addNamespace,
+    addNamespaceIfAbsent,
+    addTransport,
+    addTransportIfAbsent,
+    initProjectConfiguration,
+    resolveNamespace,
+    setNamespace,
+    setTransport,
+} from "./configuration";
 import { remoteInvoke } from "./remote-invoke";
+import { Sdk } from "./sdk";
 
-export { addNamespace, addTransport, initProjectConfiguration, resolveNamespace } from "./configuration";
-export type { Configuration, Context, NamespaceMapping, TransportHandler } from "./configuration";
-export { deserialize, remoteInvoke, serialize };
+export {
+    addNamespace,
+    addNamespaceIfAbsent,
+    addTransport,
+    addTransportIfAbsent,
+    deserialize,
+    initProjectConfiguration,
+    remoteInvoke,
+    resolveNamespace,
+    Sdk,
+    serialize,
+    setNamespace,
+    setTransport,
+};
+export type { Configuration, Context, NamespaceMapping, TransportHandler };

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -5,17 +5,43 @@
  * ---------------------------------------------------------------------------------------------
  */
 
-import type {NamespaceMapping, TransportHandler} from "./configuration";
-import {addNamespace, addTransport} from "./configuration";
+import {
+    addNamespace,
+    addNamespaceIfAbsent,
+    addTransport,
+    addTransportIfAbsent,
+    NamespaceMapping,
+    setNamespace,
+    setTransport,
+    TransportHandler,
+} from "./configuration";
 
 export class Sdk {
     public addNamespace(name: string, mapping: NamespaceMapping): this | never {
         addNamespace(name, mapping);
         return this;
     }
+    public addNamespaceIfAbsent(name: string, mapping: NamespaceMapping): this {
+        addNamespaceIfAbsent(name, mapping);
+        return this;
+    }
+    public setNamespace(name: string, mapping: NamespaceMapping): this {
+        setNamespace(name, mapping);
+        return this;
+    }
 
     public addTransport(name: string, transport: TransportHandler): this | never {
         addTransport(name, transport);
+        return this;
+    }
+
+    public addTransportIfAbsent(name: string, transport: TransportHandler): this {
+        addTransportIfAbsent(name, transport);
+        return this;
+    }
+
+    public setTransport(name: string, transport: TransportHandler): this {
+        setTransport(name, transport);
         return this;
     }
 }

--- a/packages/server/src/configuration/configuration-repository.ts
+++ b/packages/server/src/configuration/configuration-repository.ts
@@ -6,14 +6,14 @@
  */
 
 /* eslint-disable no-var */
-import {Configuration} from "./Configuration";
-import {getDefaultConfiguration} from "./default-configuration";
+import { Configuration } from "./Configuration";
+import { getDefaultConfiguration } from "./default-configuration";
 
 declare global {
     var __qsMagellanServerConfig__: Configuration;
 }
 
-export const initProjectConfiguration = (projectConfiguration: Configuration): Configuration => {
+export const initProjectConfiguration = (projectConfiguration: Partial<Configuration>): Configuration => {
     return setConfiguration(expandConfig(projectConfiguration));
 };
 
@@ -25,9 +25,9 @@ export const setConfiguration = (config: Configuration): Configuration => {
     return (global.__qsMagellanServerConfig__ = config);
 };
 
-const expandConfig = (configuration: Configuration | undefined): Configuration => {
+const expandConfig = (configuration: Partial<Configuration> | undefined): Configuration => {
     return {
         ...getDefaultConfiguration(),
-        ...configuration
+        ...configuration,
     };
 };

--- a/packages/server/src/configuration/index.ts
+++ b/packages/server/src/configuration/index.ts
@@ -4,8 +4,8 @@
  *   Licensed under the MIT License. See LICENSE in the project root for license information.
  * ---------------------------------------------------------------------------------------------
  */
-export type {TransportHandler, NamespaceMapping, Configuration} from "./Configuration";
-export {getConfiguration, initProjectConfiguration} from "./configuration-repository";
-export type {ResolvedNamespace} from "./ResolvedNamespace";
-export type {Context} from "./Context";
-export { addNamespace, addTransport, resolveNamespace } from "./namespace";
+export type { Configuration, NamespaceMapping, TransportHandler } from "./Configuration";
+export { getConfiguration, initProjectConfiguration } from "./configuration-repository";
+export type { Context } from "./Context";
+export { addNamespace, addNamespaceIfAbsent, addTransport, addTransportIfAbsent, resolveNamespace, setNamespace, setTransport } from "./namespace";
+export type { ResolvedNamespace } from "./ResolvedNamespace";

--- a/packages/server/src/configuration/namespace.spec.ts
+++ b/packages/server/src/configuration/namespace.spec.ts
@@ -1,0 +1,132 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
+import { getConfiguration, initProjectConfiguration } from "./configuration-repository";
+import { addNamespace, addNamespaceIfAbsent, addTransport, addTransportIfAbsent, setNamespace, setTransport } from "./namespace";
+
+const defaultTransport = jest.fn();
+
+beforeEach(() => {
+    initProjectConfiguration({ namespaces: { default: { endpoint: "/api", transport: "default" } }, transports: { default: defaultTransport } });
+});
+
+describe("addNamespace", () => {
+    it("should add namespace if it does not exist", () => {
+        const expected = { endpoint: "/expected", transport: "expected" };
+
+        addNamespace("expected", expected);
+
+        expect(getConfiguration().namespaces).toEqual({
+            default: { endpoint: "/api", transport: "default" },
+            expected: expected,
+        });
+    });
+
+    it("should throw error when namespace is added that already exists", () => {
+        expect(() => addNamespace("default", { endpoint: "/expected", transport: "expected" })).toThrow(
+            new Error('Namespace "default" already registered.')
+        );
+    });
+});
+
+describe("addNamespaceIfAbsent", () => {
+    it("should add namespace if it does not exist", () => {
+        const expected = { endpoint: "/expected", transport: "expected" };
+
+        addNamespaceIfAbsent("expected", expected);
+
+        expect(getConfiguration().namespaces).toEqual({
+            default: { endpoint: "/api", transport: "default" },
+            expected: expected,
+        });
+    });
+
+    it("should not add or alter namespace if it exists", () => {
+        addNamespaceIfAbsent("default", { endpoint: "/expected", transport: "expected" });
+
+        expect(getConfiguration().namespaces).toEqual({ default: { endpoint: "/api", transport: "default" } });
+    });
+});
+
+describe("setNamespace", () => {
+    it("should replace the default namespace", () => {
+        const expected = { endpoint: "/expected", transport: "expected" };
+
+        setNamespace("default", expected);
+
+        expect(getConfiguration().namespaces).toEqual({ default: expected });
+    });
+
+    it("should add namespace if it does not exist", () => {
+        const expected = { endpoint: "/expected", transport: "expected" };
+
+        setNamespace("expected", expected);
+
+        expect(getConfiguration().namespaces).toEqual({
+            default: { endpoint: "/api", transport: "default" },
+            expected: expected,
+        });
+    });
+});
+
+describe("addTransport", () => {
+    it("should add transport if it does not exist", () => {
+        const expected = jest.fn();
+
+        addTransport("expected", expected);
+
+        expect(getConfiguration().transports).toEqual({
+            default: defaultTransport,
+            expected: expected,
+        });
+    });
+
+    it("should throw error when transport is added that already exists", () => {
+        expect(() => addTransport("default", jest.fn())).toThrow(new Error('Transport "default" already registered.'));
+    });
+});
+
+describe("addTransportIfAbsent", () => {
+    it("should add transport if it does not exist", () => {
+        const expected = jest.fn();
+
+        addTransportIfAbsent("expected", expected);
+
+        expect(getConfiguration().transports).toEqual({
+            default: defaultTransport,
+            expected: expected,
+        });
+    });
+
+    it("should not add or alter transport if it exists", () => {
+        const target = jest.fn();
+
+        addTransportIfAbsent("default", target);
+
+        expect(getConfiguration().transports).toEqual({ default: defaultTransport });
+    });
+});
+
+describe("setTransport", () => {
+    it("should replace the default transport", () => {
+        const expected = jest.fn();
+
+        setTransport("default", expected);
+
+        expect(getConfiguration().transports).toEqual({ default: expected });
+    });
+
+    it("should add transport if it does not exist", () => {
+        const expected = jest.fn();
+
+        setTransport("expected", expected);
+
+        expect(getConfiguration().transports).toEqual({
+            default: defaultTransport,
+            expected: expected,
+        });
+    });
+});

--- a/packages/server/src/configuration/namespace.ts
+++ b/packages/server/src/configuration/namespace.ts
@@ -12,13 +12,37 @@ import { ResolvedNamespace } from "./ResolvedNamespace";
 
 export const addNamespace = (namespace: string, mapping: NamespaceMapping): void | never => {
     const config = getConfiguration();
-    assert(!config.namespaces[namespace], `Namespace ${namespace} already registered.`);
+    assert(!config.namespaces[namespace], `Namespace "${namespace}" already registered.`);
+    config.namespaces[namespace] = mapping;
+};
+
+export const addNamespaceIfAbsent = (namespace: string, mapping: NamespaceMapping): void => {
+    const config = getConfiguration();
+    if (!config.namespaces[namespace]) {
+        config.namespaces[namespace] = mapping;
+    }
+};
+
+export const setNamespace = (namespace: string, mapping: NamespaceMapping): void => {
+    const config = getConfiguration();
     config.namespaces[namespace] = mapping;
 };
 
 export const addTransport = (name: string, handler: TransportHandler): void | never => {
     const config = getConfiguration();
-    assert(!config.transports[name], `Transport ${name} already registered.`);
+    assert(!config.transports[name], `Transport "${name}" already registered.`);
+    config.transports[name] = handler;
+};
+
+export const addTransportIfAbsent = (name: string, handler: TransportHandler): void => {
+    const config = getConfiguration();
+    if (!config.transports[name]) {
+        config.transports[name] = handler;
+    }
+};
+
+export const setTransport = (name: string, handler: TransportHandler): void => {
+    const config = getConfiguration();
     config.transports[name] = handler;
 };
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,11 +4,30 @@
  *   Licensed under the MIT License. See LICENSE in the project root for license information.
  * ---------------------------------------------------------------------------------------------
  */
-import {serve, ServerOptions} from "./server";
-import {externalFunctionInvoke} from "./services";
+import type { Configuration, Context, NamespaceMapping, TransportHandler } from "./configuration";
+import {
+    addNamespace,
+    addNamespaceIfAbsent,
+    addTransport,
+    addTransportIfAbsent,
+    initProjectConfiguration,
+    resolveNamespace,
+    setNamespace,
+    setTransport,
+} from "./configuration";
+import { serve, ServerOptions } from "./server";
+import { externalFunctionInvoke } from "./services";
 
-export {serve, externalFunctionInvoke};
-export type {ServerOptions};
-
-export type { Configuration, Context, NamespaceMapping, TransportHandler } from "./configuration";
-export { addNamespace, addTransport, initProjectConfiguration, resolveNamespace } from "./configuration";
+export type { ServerOptions, Configuration, Context, NamespaceMapping, TransportHandler };
+export {
+    addNamespace,
+    addNamespaceIfAbsent,
+    addTransport,
+    addTransportIfAbsent,
+    externalFunctionInvoke,
+    initProjectConfiguration,
+    resolveNamespace,
+    serve,
+    setNamespace,
+    setTransport,
+};

--- a/packages/server/src/sdk.ts
+++ b/packages/server/src/sdk.ts
@@ -5,8 +5,17 @@
  * ---------------------------------------------------------------------------------------------
  */
 
-import {FunctionService, ServerFunction} from "./services";
-import {addNamespace, addTransport, NamespaceMapping, TransportHandler} from "./configuration";
+import {
+    addNamespace,
+    addNamespaceIfAbsent,
+    addTransport,
+    addTransportIfAbsent,
+    NamespaceMapping,
+    setNamespace,
+    setTransport,
+    TransportHandler,
+} from "./configuration";
+import { FunctionService, ServerFunction } from "./services";
 
 // TODO: Move type declaration to global.d.ts
 declare global {
@@ -27,7 +36,7 @@ export class Sdk {
     }
 
     public invokeFunction<I, O>(name: string, data: I, namespace = "default"): Promise<O> {
-        return this.service.invokeFunction({name, data, namespace});
+        return this.service.invokeFunction({ name, data, namespace });
     }
 
     public addNamespace(name: string, mapping: NamespaceMapping): this | never {
@@ -35,8 +44,28 @@ export class Sdk {
         return this;
     }
 
+    public addNamespaceIfAbsent(name: string, mapping: NamespaceMapping): this | never {
+        addNamespaceIfAbsent(name, mapping);
+        return this;
+    }
+
+    public setNamespace(name: string, mapping: NamespaceMapping): this | never {
+        setNamespace(name, mapping);
+        return this;
+    }
+
     public addTransport(name: string, transport: TransportHandler): this | never {
         addTransport(name, transport);
+        return this;
+    }
+
+    public addTransportIfAbsent(name: string, transport: TransportHandler): this | never {
+        addTransportIfAbsent(name, transport);
+        return this;
+    }
+
+    public setTransport(name: string, transport: TransportHandler): this | never {
+        setTransport(name, transport);
         return this;
     }
 }


### PR DESCRIPTION
To complement and complete the existing configuration API, this PR addresses 2 open issues:

1. The ability to init a partial configuration that is completed with default content.
2. To add(Namespace|Transport) if they do not yet exist or to replace a Namespace|Transport if they already exist.