### PR TITLE
f Adds support for LocalDate(Time) serialization

### DIFF
--- a/Release-Notes.md
+++ b/Release-Notes.md
@@ -7,9 +7,17 @@
 
 # Releases
 
-## v0.1.0
+## v0.1.3
 
 > TBD
+
+### Additional supported serializations
+
+- Feature :sparkles:: Date Transport support for LocalDate, LocalDateTime
+
+## v0.1.0
+
+> 2022-07-29
 
 ### Initial Release
 

--- a/packages/java/serialization/src/main/java/com/quatico/magellan/TransportSerializer.java
+++ b/packages/java/serialization/src/main/java/com/quatico/magellan/TransportSerializer.java
@@ -7,33 +7,48 @@
 package com.quatico.magellan;
 
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
-
 import com.quatico.magellan.serialization.DateAdapterFactory;
+import com.quatico.magellan.serialization.LocalDateAdapter;
+import com.quatico.magellan.serialization.LocalDateTimeAdapter;
 import com.quatico.magellan.serialization.MapAdapterFactory;
 import com.quatico.magellan.serialization.SetAdapterFactory;
 import com.quatico.magellan.serialization.UtcDateAdapter;
 
 
 public class TransportSerializer {
+    static final String dateFormat     = "yyyy-MM-dd";
+    static final String dateTimeFormat = String.format("%s'T'HH:mm:ss.SSS'Z'",dateFormat);
     private final Gson gson;
     
     public TransportSerializer() {
         gson = getGson(new GsonBuilder());
     }
     
+    public static String getDateFormat() {
+        return dateFormat;
+    }
+    
+    public static String getDateTimeFormat() {
+        return dateTimeFormat;
+    }
+    
     private static Gson getGson(GsonBuilder builder) {
         return builder.registerTypeAdapter(Date.class, new UtcDateAdapter())
+                      .registerTypeAdapter(LocalDate.class, new LocalDateAdapter())
+                      .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter())
                       .registerTypeAdapterFactory(new DateAdapterFactory())
                       .registerTypeAdapterFactory(new SetAdapterFactory())
                       .registerTypeAdapterFactory(new MapAdapterFactory())
                       .serializeNulls()
-                      .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+                      .setDateFormat(dateTimeFormat)
                       .create();
     }
     

--- a/packages/java/serialization/src/main/java/com/quatico/magellan/serialization/LocalDateAdapter.java
+++ b/packages/java/serialization/src/main/java/com/quatico/magellan/serialization/LocalDateAdapter.java
@@ -1,0 +1,47 @@
+/*
+---------------------------------------------------------------------------------------------
+  Copyright (c) Quatico Solutions AG. All rights reserved.
+  Licensed under the MIT License. See LICENSE in the project root for license information.
+---------------------------------------------------------------------------------------------
+*/
+package com.quatico.magellan.serialization;
+
+
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.quatico.magellan.TransportSerializer;
+
+
+public class LocalDateAdapter implements JsonSerializer<LocalDate>, JsonDeserializer<LocalDate> {
+    private static final DateTimeFormatter formatter            = DateTimeFormatter.ofPattern(TransportSerializer.getDateFormat());
+    
+    @Override
+    public JsonElement serialize(LocalDate localDate, Type srcType, JsonSerializationContext context) {
+        JsonObject result = new JsonObject();
+        result.addProperty("__type__", "date");
+        result.add("value", new JsonPrimitive(String.format("%sT00:00:00.000Z", formatter.format(localDate))));
+        return result;
+    }
+    
+    @Override
+    public LocalDate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        JsonObject obj = json.getAsJsonObject();
+        if(obj.get("__type__").getAsString().equals("date")) {
+            return LocalDate.parse(
+                    obj.get("value").getAsString(),
+                    DateTimeFormatter.ofPattern(TransportSerializer.getDateTimeFormat()));
+        }
+        throw new JsonParseException("Not a valid LocalDate string");
+    }
+}

--- a/packages/java/serialization/src/main/java/com/quatico/magellan/serialization/LocalDateTimeAdapter.java
+++ b/packages/java/serialization/src/main/java/com/quatico/magellan/serialization/LocalDateTimeAdapter.java
@@ -1,0 +1,47 @@
+/*
+---------------------------------------------------------------------------------------------
+  Copyright (c) Quatico Solutions AG. All rights reserved.
+  Licensed under the MIT License. See LICENSE in the project root for license information.
+---------------------------------------------------------------------------------------------
+*/
+package com.quatico.magellan.serialization;
+
+
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.quatico.magellan.TransportSerializer;
+
+
+public class LocalDateTimeAdapter implements JsonSerializer<LocalDateTime>, JsonDeserializer<LocalDateTime> {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(TransportSerializer.getDateTimeFormat());
+    
+    @Override
+    public JsonElement serialize(LocalDateTime localDateTime, Type srcType, JsonSerializationContext context) {
+        JsonObject result = new JsonObject();
+        result.addProperty("__type__", "date");
+        result.add("value", new JsonPrimitive(formatter.format(localDateTime)));
+        return result;
+    }
+    
+    @Override
+    public LocalDateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        JsonObject obj = json.getAsJsonObject();
+        if (obj.get("__type__").getAsString().equals("date")) {
+            return LocalDateTime.parse(
+                    obj.get("value").getAsString(),
+                    DateTimeFormatter.ofPattern(TransportSerializer.getDateTimeFormat()));
+        }
+        throw new JsonParseException("Not a valid LocalDate string");
+    }
+}

--- a/packages/java/serialization/src/test/java/com/quatico/magellan/serialization/LocalDateAdapterTest.java
+++ b/packages/java/serialization/src/test/java/com/quatico/magellan/serialization/LocalDateAdapterTest.java
@@ -1,0 +1,55 @@
+/*
+---------------------------------------------------------------------------------------------
+  Copyright (c) Quatico Solutions AG. All rights reserved.
+  Licensed under the MIT License. See LICENSE in the project root for license information.
+---------------------------------------------------------------------------------------------
+*/
+package com.quatico.magellan.serialization;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+
+public class LocalDateAdapterTest {
+    private static Gson target;
+    
+    @BeforeAll
+    public static void setUpTest() {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+        GsonBuilder gsonBuilder = new GsonBuilder()
+                .registerTypeAdapter(LocalDate.class, new LocalDateAdapter());
+        gsonBuilder = gsonBuilder.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+        target = gsonBuilder.create();
+    }
+    
+    @AfterAll
+    public static void cleanUpTest() {
+        target = null;
+    }
+    
+    @Test
+    public void serialize_LocalDate_EqualToJson() {
+        String actual = LocalDateAdapterTest.target.toJson(LocalDate.of(2022, 07, 01) );
+        
+        assertEquals("{\"__type__\":\"date\",\"value\":\"2022-07-01T00:00:00.000Z\"}", actual);
+    }
+    
+    @Test
+    public void deserialize_LocalDateJson_EqualToLocalDate() {
+        LocalDate actual = target.fromJson("{\"__type__\":\"date\",\"value\":\"2022-07-01T00:00:00.000Z\"}", LocalDate.class);
+        
+        assertEquals(LocalDate.of(2022,07,01), actual);
+    }
+    
+}

--- a/packages/java/serialization/src/test/java/com/quatico/magellan/serialization/LocalDateTimeAdapterTest.java
+++ b/packages/java/serialization/src/test/java/com/quatico/magellan/serialization/LocalDateTimeAdapterTest.java
@@ -1,0 +1,54 @@
+/*
+---------------------------------------------------------------------------------------------
+  Copyright (c) Quatico Solutions AG. All rights reserved.
+  Licensed under the MIT License. See LICENSE in the project root for license information.
+---------------------------------------------------------------------------------------------
+*/
+package com.quatico.magellan.serialization;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+
+public class LocalDateTimeAdapterTest {
+    private static Gson target;
+    
+    @BeforeAll
+    public static void setUpTest() {
+        GsonBuilder gsonBuilder = new GsonBuilder()
+                .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter());
+        gsonBuilder = gsonBuilder.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+        target = gsonBuilder.create();
+    }
+    
+    @AfterAll
+    public static void cleanUpTest() {
+        target = null;
+    }
+    
+    @Test
+    public void serialize_LocalDateTime_EqualToJson() {
+        String actual = target.toJson(LocalDateTime.of(2022, 7, 1, 0, 0, 0));
+        
+        assertEquals("{\"__type__\":\"date\",\"value\":\"2022-07-01T00:00:00.000Z\"}", actual);
+    }
+    
+    @Test
+    public void deserialize_LocalDateTimeJson_EqualToLocalDateTime() {
+        LocalDateTime actual = target.fromJson("{\"__type__\":\"date\",\"value\":\"2022-07-01T00:00:00.000Z\"}", LocalDateTime.class);
+        
+        assertEquals(LocalDateTime.of(2022, 7, 1, 0, 0, 0), actual);
+    }
+    
+}


### PR DESCRIPTION
This adds support to (de)serialize java.time.LocalDate and java.time.LocalDateTime as date objects for the transport consistent with the existing JavaScript Date and java.util.Date (de)serialization implementation.