### PR TITLE
E Updates java build pipeline to run all steps online

### DIFF
--- a/packages/java/package.json
+++ b/packages/java/package.json
@@ -19,9 +19,9 @@
         "clean": "mvn clean",
         "lint": "mvn process-sources -B -o",
         "build": "mvn install -DskipTests -Dcheckstyle.skip -B",
-        "test": "mvn test -B -o -Dcheckstyle.skip",
-        "test:update": "mvn test -o -Dcheckstyle.skip",
-        "test:e2e": "mvn test -Pe2e -B -o -Dcheckstyle.skip",
+        "test": "mvn test -B -Dcheckstyle.skip",
+        "test:update": "mvn test -Dcheckstyle.skip",
+        "test:e2e": "mvn test -Pe2e -B -Dcheckstyle.skip",
         "deploy:test": "mvn deploy -DaltDeploymentRepository=ossrh::default::file:./tmp-deploy",
         "install": "mvn dependency:tree"
     },


### PR DESCRIPTION
To optimize the process, it previously didn't run the distinct steps with maven online as the dependency install was meant to ensure that everything is already fully installed.