### PR TITLE
Test classes to prevent invalid attempts to serialize local or anonymous classes

### DIFF
--- a/packages/java/serialization/.flattened-pom.xml
+++ b/packages/java/serialization/.flattened-pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.quatico.magellan</groupId>
   <artifactId>serialization</artifactId>
-  <version>0.1.3</version>
+  <version>0.1.4-SNAPSHOT</version>
   <name>Quatico Solutions AG :: Magellan Serialization</name>
   <description>Magellan Serialization Module representing the Java Counterpart confirming to the same JSON input/output as the Magellan TypeScript packages.</description>
   <url>https://github.com/quatico-solutions/magellan/packages/java/serialization</url>
@@ -20,7 +20,7 @@
       <id></id>
       <name>Marc Schaerer</name>
       <organization>Quatico Solutions AG</organization>
-      <organizationUrl>https://quatico.com</organizationUrl>
+      <organizationUrl>https://www.quatico.com</organizationUrl>
       <roles>
         <role>Project-Administrator</role>
         <role>Developer</role>

--- a/packages/java/serialization/src/main/java/com/quatico/magellan/TransportSerializer.java
+++ b/packages/java/serialization/src/main/java/com/quatico/magellan/TransportSerializer.java
@@ -24,20 +24,20 @@ import com.quatico.magellan.serialization.UtcDateAdapter;
 
 
 public class TransportSerializer {
-    static final String dateFormat     = "yyyy-MM-dd";
-    static final String dateTimeFormat = String.format("%s'T'HH:mm:ss.SSS'Z'",dateFormat);
-    private final Gson gson;
+    static final  String DATE_FORMAT     = "yyyy-MM-dd";
+    static final  String DATETIME_FORMAT = String.format("%s'T'HH:mm:ss.SSS'Z'", DATE_FORMAT);
+    private final Gson   gson;
     
     public TransportSerializer() {
         gson = getGson(new GsonBuilder());
     }
     
     public static String getDateFormat() {
-        return dateFormat;
+        return DATE_FORMAT;
     }
     
     public static String getDateTimeFormat() {
-        return dateTimeFormat;
+        return DATETIME_FORMAT;
     }
     
     private static Gson getGson(GsonBuilder builder) {
@@ -48,7 +48,7 @@ public class TransportSerializer {
                       .registerTypeAdapterFactory(new SetAdapterFactory())
                       .registerTypeAdapterFactory(new MapAdapterFactory())
                       .serializeNulls()
-                      .setDateFormat(dateTimeFormat)
+                      .setDateFormat(DATETIME_FORMAT)
                       .create();
     }
     
@@ -56,7 +56,19 @@ public class TransportSerializer {
         if (objToSerialise == null) {
             throw new IllegalArgumentException("objToSerialise must not be null");
         }
-        
+    
+        if (objToSerialise.getClass().isAnonymousClass()) {
+            throw new IllegalArgumentException(String.format(
+                    "objToSerialise class %s must not be a anonymous class",
+                    objToSerialise.getClass().getName()));
+        }
+    
+        if (objToSerialise.getClass().isLocalClass()) {
+            throw new IllegalArgumentException(String.format(
+                    "objToSerialise class %s must not be a local class",
+                    objToSerialise.getClass().getName()));
+        }
+    
         return gson.toJson(objToSerialise);
     }
     


### PR DESCRIPTION
This addresses a problem where the serialisation did not check if an object is a local or anonymous class before attempting to serialise it.
This causes intractable problems due to a limitation in GSON (https://github.com/google/gson/issues/298) where the serialisation will not fail but return null causing the result of the java serialisation to not match the result of the typescript serialisation.