### PR TITLE
CI Add release note extraction for releases

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -74,6 +74,12 @@ jobs:
       - name: E2E tests
         run: yarn test:e2e
 
+      - name: Extract release notes
+        id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v1
+        with:
+          changelog_file: Release-Notes.md
+          
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@v1
         env:
@@ -94,6 +100,8 @@ jobs:
       - name: create release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body: ${{ steps.extract-release-notes.outputs.release_notes }}
         env:
           # The workflow permissions of the project must be updated to 'Workflows have read and write permissions in the repository for all scopes'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Release-Notes.md
+++ b/Release-Notes.md
@@ -4,44 +4,48 @@
    Licensed under the MIT License. See LICENSE in the project root for license information.
  ---------------------------------------------------------------------------------------------
 -->
+<!-- markdownlint-disable MD024 -->
 
 # Releases
 
-## v0.1.5
+Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.0.0/) format.
 
-> TBA
+## [Unreleased]
 
-### TBD
+### Changed
 
-- Improvement :gift_heart:: magellan-server has tslib as production dependency to ease integration in custom servers.
+- magellan-server has tslib as production dependency to ease integration in custom servers.
 
-## v0.1.4
+## [0.1.4] - 2022-11-08
 
-> 2022-11-08
+SPA Routing
 
-### Routing
+### Added
 
-- Feature :sparkles:: Wildcard paths not pointing to static files now redirect to the static root path.
+- Wildcard paths not pointing to static files now redirect to the static root path.
 
-## v0.1.3
+## [0.1.3] - 2022-08-04
 
-> 2022-08-04
+Additional supported serializations
 
-### Additional supported serializations
+### Added
 
-- Feature :sparkles:: Implements date transport support for LocalDate and LocalDateTime.
-- Bugfix :pill:: Implements logic to handle incomplete replacement transport configurations.
+- Implements date transport support for LocalDate and LocalDateTime.
 
-## v0.1.0
+### Fixed
 
-> 2022-07-29
+- Implements logic to handle incomplete replacement transport configurations.
 
-### Initial Release
+## [0.1.0] - 2022-07-29
 
-- Feature :sparkles:: (Almost) invisible transport layer between browser and JVM
-- Feature :sparkles:: Effortless configuration of service endpoints
-- Feature :sparkles:: Automatic serialization of input/output values
-- Feature :sparkles:: Transparent error messages and exception handling
+Initial Release
+
+### Added
+
+- (Almost) invisible transport layer between browser and JVM
+- Effortless configuration of service endpoints
+- Automatic serialization of input/output values
+- Transparent error messages and exception handling
 
 ## vx.y.z
 


### PR DESCRIPTION
The look of the extracted release notes on CI generated Github releases, based on the structure of Added, Changed etc is
![image](https://user-images.githubusercontent.com/1495943/202727926-dcf237db-a1d6-4b50-a83d-728b162261bd.png)
