### PR TITLE
E Pin the monorepo internal package version dependencies

### DIFF
--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -53,8 +53,8 @@
         "ts-jest": "^29.0.3"
     },
     "dependencies": {
-        "@quatico/magellan-client": "^0.1.4",
-        "@quatico/magellan-server": "^0.1.4",
+        "@quatico/magellan-client": "0.1.4",
+        "@quatico/magellan-server": "0.1.4",
         "@quatico/websmith-api": "^0.2.2",
         "typescript": "^4.6.3"
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,8 +40,8 @@
         "publish-npm": "npm publish --access public"
     },
     "dependencies": {
-        "@quatico/magellan-client": "^0.1.4",
-        "@quatico/magellan-server": "^0.1.4",
+        "@quatico/magellan-client": "0.1.4",
+        "@quatico/magellan-server": "0.1.4",
         "@quatico/websmith-api": "^0.2.2",
         "@quatico/websmith-cli": "^0.2.2",
         "@quatico/websmith-compiler": "^0.2.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,7 +33,7 @@
         "publish-npm": "npm publish --access public"
     },
     "dependencies": {
-        "@quatico/magellan-shared": "^0.1.4"
+        "@quatico/magellan-shared": "0.1.4"
     },
     "devDependencies": {
         "@swc/core": "^1.3.16",

--- a/packages/java/package.json
+++ b/packages/java/package.json
@@ -26,6 +26,6 @@
         "install": "mvn dependency:tree"
     },
     "devDependencies": {
-        "@quatico/magellan-shared": "^0.1.4"
+        "@quatico/magellan-shared": "0.1.4"
     }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,7 +34,7 @@
         "publish-npm": "npm publish --access public"
     },
     "dependencies": {
-        "@quatico/magellan-shared": "^0.1.4",
+        "@quatico/magellan-shared": "0.1.4",
         "ajv": "8.9.0",
         "cookie-parser": "~1.4.4",
         "cors": "2.8.5",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -41,10 +41,10 @@
     },
     "dependencies": {
         "@cucumber/cucumber": "^8.7.0",
-        "@quatico/magellan-cli": "^0.1.4",
-        "@quatico/magellan-client": "^0.1.4",
-        "@quatico/magellan-server": "^0.1.4",
-        "@quatico/magellan-shared": "^0.1.4",
+        "@quatico/magellan-cli": "0.1.4",
+        "@quatico/magellan-client": "0.1.4",
+        "@quatico/magellan-server": "0.1.4",
+        "@quatico/magellan-shared": "0.1.4",
         "typescript": "~4.7.4"
     },
     "engines": {


### PR DESCRIPTION
This is intended to ensure that the version remains consistent across the monorepository, avoiding public package dependency to have higher versions than the public packages themself.

For example importing magellan-cli@0.1.1 at this moment will resolve the version 0.1.4 for the packages depenendencies magellan-client and magellan-server, not 0.1.1