### PR TITLE
Add cli version output

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,10 +6,12 @@
  * ---------------------------------------------------------------------------------------------
  */
 import { Command } from "commander";
-import { addServeCommand } from "./server";
 import { addCompileCommand } from "./compiler";
+import { getVersion } from "./extract-version";
+import { addServeCommand } from "./server";
 
 const command = new Command();
 addCompileCommand(command);
 addServeCommand(command);
+command.addHelpText("beforeAll", `Magellan version ${getVersion()}`);
 command.parse(process.argv);

--- a/packages/cli/src/compiler/command.spec.ts
+++ b/packages/cli/src/compiler/command.spec.ts
@@ -12,6 +12,7 @@ import { Command } from "commander";
 import { writeFileSync } from "fs";
 import { resolve } from "path";
 import ts from "typescript";
+import { getVersion } from "../extract-version";
 import { addCompileCommand } from "./command";
 
 class CompilerTestClass extends Compiler {
@@ -127,6 +128,17 @@ describe("addCompileCommand", () => {
             },
         });
         expect(target.testOptions!.targets).toEqual(["client", "server"]);
+    });
+
+    it("should output the cli version", () => {
+        const target = jest.fn();
+        console.info = target;
+
+        addCompileCommand(new Command(), new CompilerTestClass(createOptions({}), system)).parse(["compile"], {
+            from: "user",
+        });
+
+        expect(target).toHaveBeenCalledWith(`Magellan version ${getVersion()}`);
     });
 
     it("should set project option  w/ --project cli argument", () => {

--- a/packages/cli/src/compiler/command.ts
+++ b/packages/cli/src/compiler/command.ts
@@ -10,6 +10,7 @@ import { addCompileCommand as addWebsmithCompileCommand } from "@quatico/websmit
 import { Compiler } from "@quatico/websmith-compiler";
 import { Command } from "commander";
 import parseArgs from "minimist";
+import { getVersion } from "../extract-version";
 import { CliArguments } from "./CliArguments";
 
 export const addCompileCommand = (parent = new Command(), compiler?: Compiler) => {
@@ -49,6 +50,8 @@ export const addCompileCommand = (parent = new Command(), compiler?: Compiler) =
             }
         })
         .action((args: CliArguments, command: Command) => {
+            // eslint-disable-next-line no-console
+            console.info(`Magellan version ${getVersion()}`);
             if (command.args) {
                 const unknownArgs = command.args.filter(arg => !command.getOptionValueSource(arg));
                 if (unknownArgs?.length > 0) {

--- a/packages/cli/src/extract-version.ts
+++ b/packages/cli/src/extract-version.ts
@@ -1,0 +1,11 @@
+/*
+ * ---------------------------------------------------------------------------------------------
+ *   Copyright (c) Quatico Solutions AG. All rights reserved.
+ *   Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ---------------------------------------------------------------------------------------------
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export const getVersion = () => JSON.parse(readFileSync(join(__dirname, "..", "package.json")).toString()).version ?? "unknown";

--- a/packages/cli/src/server/command.spec.ts
+++ b/packages/cli/src/server/command.spec.ts
@@ -5,9 +5,10 @@
  * ---------------------------------------------------------------------------------------------
  */
 /* eslint-disable no-console */
-import { mkdirSync } from "fs";
-import { addServeCommand } from "./command";
 import { Command } from "commander";
+import { mkdirSync } from "fs";
+import { getVersion } from "../extract-version";
+import { addServeCommand } from "./command";
 
 describe("addServeCommand", () => {
     it("should set the default options w/ valid functionScriptPath", () => {
@@ -22,6 +23,16 @@ describe("addServeCommand", () => {
             port: 3000,
             staticDir: "./resources",
         });
+    });
+
+    it("should output the cli version", () => {
+        setupFolders("./resources", "./server-esm");
+        const target = jest.fn();
+        console.info = target;
+
+        addServeCommand(new Command(), jest.fn()).parse(["serve", "./resource", "-s", "./server-esm"], { from: "user" });
+
+        expect(target).toHaveBeenCalledWith(`Magellan version ${getVersion()}`);
     });
 
     it("should show the command help w/o staticDir", () => {

--- a/packages/cli/src/server/command.ts
+++ b/packages/cli/src/server/command.ts
@@ -8,6 +8,7 @@
 import { serve, ServerOptions } from "@quatico/magellan-server";
 import { Command } from "commander";
 import { existsSync } from "fs";
+import { getVersion } from "../extract-version";
 import { createOptions, getServerModuleDir } from "./options";
 
 export const addServeCommand = (parent = new Command(), serveFn: (options: ServerOptions) => void = serve): Command => {
@@ -24,6 +25,8 @@ export const addServeCommand = (parent = new Command(), serveFn: (options: Serve
         .option("-p, --port <port>", "port for the standalone HTTP server", num => parseInt(num, 10), 3000)
         .option("-d, --debug", "enable the output of debug information", false)
         .action((staticDir: string, args: Partial<ServerOptions>, command: Command) => {
+            // eslint-disable-next-line no-console
+            console.info(`Magellan version ${getVersion()}`);
             const serverModuleDir = getServerModuleDir(args);
             if (typeof serverModuleDir !== "string") {
                 // eslint-disable-next-line no-console


### PR DESCRIPTION
This adds the Magellan cli version extracted from the CLIs package.json to every CLI commands run including the command help, formatted as "Magellan version [version]"

This arose from the effort to upgrade to @quatico/websmith version 0.3.4