### PR TITLE
Extend server to client error communication

### DIFF
--- a/packages/server/src/routes/function-route.spec.ts
+++ b/packages/server/src/routes/function-route.spec.ts
@@ -7,6 +7,7 @@
 import { unpackPayload } from "@quatico/magellan-shared";
 import express, { Express } from "express";
 import multer from "multer";
+import { join } from "path";
 import request from "supertest";
 import { Sdk } from "../sdk";
 import { initDependencyContext } from "../services";
@@ -65,8 +66,11 @@ describe("createStaticRoute", () => {
         expect(res.header["content-type"]).toBe("application/json; charset=utf-8");
         const payload = unpackPayload(res.body);
         expect(payload.error).toEqual({
-            message: 'Function request to "expected" failed.',
-            error: "expected error message",
+            message: "expected error message",
+            error: expect.stringContaining(
+                "Error: expected error message\n" +
+                `    at ${join(__dirname, "function-route.spec.ts")}`
+            ),
         });
         expect(res.statusCode).toBe(200);
     });
@@ -93,7 +97,7 @@ describe("createStaticRoute", () => {
 
         expect(res.header["content-type"]).toBe("application/json; charset=utf-8");
         const payload = unpackPayload(res.body);
-        expect(payload.error).toEqual({ message: 'Function request to "expected" failed.' });
+        expect(payload.error).toEqual({ message: 'expected error message' });
         expect(res.statusCode).toBe(200);
     });
 

--- a/packages/server/src/routes/function-route.ts
+++ b/packages/server/src/routes/function-route.ts
@@ -31,10 +31,12 @@ export const createFunctionRoute = (sdk = new Sdk()) => {
             } catch (err) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const error = err as Error;
+                // eslint-disable-next-line no-console
+                console.error(`received error ${error.message} with stack`, error.stack);
                 res.status(200).end(
                     serializeError({
-                        message: `Function request to "${name}" failed.`,
-                        ...(!isProductionEnvironment() && error && { error: error.message ?? error.toString() }),
+                        message: error.message,
+                        ...(!isProductionEnvironment() && error && { error: `${error.message}\n${error.stack}` }),
                     })
                 );
             }

--- a/packages/test/features/magellan-cli.feature
+++ b/packages/test/features/magellan-cli.feature
@@ -49,8 +49,9 @@ Feature: Magellan CLI commands
         And node environment is "development"
         When CLI command "serve" is called without arguments
         And the function "foobar" is invoked
-        Then the promise is rejected with message "Function request to \"foobar\" failed.".
+        Then the promise is rejected with message "This should have been replaced".
         And writes console error "This should have been replaced".
+        And writes console error "packages/test/output/project/lib/server/foobar.js:6:11)".
 
     Scenario: Serve command is called with error throwing function in production environment
         Given valid TypeScript project directory was created
@@ -60,7 +61,7 @@ Feature: Magellan CLI commands
         And node environment is "production"
         When CLI command "serve" is called without arguments
         And the function "foobar" is invoked
-        Then the promise is rejected with message "Function request to \"foobar\" failed.".
+        Then the promise is rejected with message "This should have been replaced".
         # And writes no console error. # Temporally disabled until websmith-compiler no longer floods the error console with ts missing files from the Typescript libraries
 
     Scenario: Serve command is called with valid pure function project configuration

--- a/packages/test/src/steps/magellan-cli.steps.ts
+++ b/packages/test/src/steps/magellan-cli.steps.ts
@@ -177,7 +177,7 @@ Before(() => {
     rmSync(resolve(targetDirectory, ".."), { recursive: true, force: true });
     // eslint-disable-next-line no-console
     console.warn = () => undefined;
-
+    previousPath = ".";
     remoteInvokeConsoleError = undefined;
     remoteInvokeError = undefined;
     remoteInvokeResult = undefined;


### PR DESCRIPTION
This enhances the implementation to include
- the original error message with stack trace in development mode with the stack trace being reported as error on the frontend console.
- the original error message and no stack in production mode with no error written to the console.