### PR TITLE
Improvement: Reject promises when the (de)serialization of data fails in transport-request

### DIFF
--- a/Release-Notes.md
+++ b/Release-Notes.md
@@ -1,7 +1,7 @@
 <!--
- ---------------------------------------------------------------------------------------------
-   Copyright (c) Quatico Solutions AG. All rights reserved.
-   Licensed under the MIT License. See LICENSE in the project root for license information.
+---------------------------------------------------------------------------------------------
+Copyright (c) Quatico Solutions AG. All rights reserved.
+Licensed under the MIT License. See LICENSE in the project root for license information.
  ---------------------------------------------------------------------------------------------
 -->
 <!-- markdownlint-disable MD024 -->
@@ -11,6 +11,12 @@
 Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+
+### New Features
+
+- Serialization and deserialization errors during transport-request handling reject the promise.
+
+## [0.2.1] - 2023-02-07
 
 ### New Features
 
@@ -26,7 +32,8 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.0.0/
 ### New Features
 
 - service functions throwing errors now yield a rejection of the client promise with the error message.
-- service functions throwing errors now yield a console.error with the error stack on the client if the server is not in production mode.
+- service functions throwing errors now yield a console.error with the error stack on the client if the server is not in
+  production mode.
 
 ### Changed
 

--- a/packages/client/src/transport/transport-request.ts
+++ b/packages/client/src/transport/transport-request.ts
@@ -23,7 +23,9 @@ export const transportRequest = async <O>(
     try {
         payload = serialization.serialize(data);
     } catch (err) {
-        throw new Error(`Cannot serialize input parameter for remote function: "${name}".`);
+        // eslint-disable-next-line no-console
+        process.env.NODE_ENV === "development" && console.error(`Cannot serialize input parameter for remote function: "${name}".`);
+        return Promise.reject("Serialization failed");
     }
 
     const { endpoint, transport } = resolveNamespace(namespace);
@@ -38,6 +40,8 @@ export const transportRequest = async <O>(
         }
         return error ? Promise.reject(error.message) : (data as O);
     } catch (err) {
-        throw new Error(`Cannot deserialize response from remote function: "${name}".`);
+        // eslint-disable-next-line no-console
+        process.env.NODE_ENV === "development" && console.error(`Cannot deserialize response from remote function: "${name}".`);
+        return Promise.reject("Deserialization failed");
     }
 };

--- a/packages/server/src/services/external-invokation.spec.ts
+++ b/packages/server/src/services/external-invokation.spec.ts
@@ -22,3 +22,7 @@ describe.skip("externalFunctionInvoke", () => {
         }).rejects.toThrow("function error: 'error during function invocation: Function not defined'");
     });
 });
+
+describe("external invocation proxy", () => {
+    it("succeeds", () => undefined);
+});


### PR DESCRIPTION
This replaces the prior logic in transport-request that made it inconsistently throw an error instead of rejecting the promise, preventing normal frontend workflows from handling and properly detecting the behavior.