### PR TITLE
Extract global types

### DIFF
--- a/packages/client/src/transport/configuration-repository.ts
+++ b/packages/client/src/transport/configuration-repository.ts
@@ -10,10 +10,6 @@ import { NamespaceMapping } from "@quatico/magellan-shared";
 import { Configuration } from "./Configuration";
 import { getDefaultConfiguration } from "./default-configuration";
 
-declare global {
-    var __qsMagellanConfig__: Configuration;
-}
-
 export const initProjectConfiguration = (projectConfiguration: Partial<Configuration>): Configuration => {
     return persistConfig(expandConfig(projectConfiguration));
 };

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -10,6 +10,7 @@
         "src/**/*.spec.tsx"
     ],
     "include": [
-        "src"
+        "src",
+        "types"
     ]
 }

--- a/packages/client/types/global.d.ts
+++ b/packages/client/types/global.d.ts
@@ -1,0 +1,7 @@
+export {};
+import { Configuration } from "../src";
+
+declare global {
+    // eslint-disable-next-line no-var
+    var __qsMagellanConfig__: Configuration;
+}

--- a/packages/server/src/configuration/configuration-repository.ts
+++ b/packages/server/src/configuration/configuration-repository.ts
@@ -12,10 +12,6 @@ import { getDependencyContext, getFunctionService } from "../services";
 import { Configuration } from "./Configuration";
 import { getDefaultConfiguration } from "./default-configuration";
 
-declare global {
-    var __qsMagellanServerConfig__: Configuration;
-}
-
 export const initProjectConfiguration = (projectConfiguration: Partial<Configuration>): Configuration => {
     return setConfiguration(expandConfig(projectConfiguration));
 };

--- a/packages/server/src/services/DependencyContext.ts
+++ b/packages/server/src/services/DependencyContext.ts
@@ -7,7 +7,7 @@
 
 /* eslint-disable no-var */
 import { TransportHandler } from "..";
-import { TransportRequest } from "../api/TransportRequest";
+import { TransportRequest } from "../api";
 
 export type DependencyContext = {
     defaultTransportRequest: TransportRequest;

--- a/packages/server/src/services/DependencyContext.ts
+++ b/packages/server/src/services/DependencyContext.ts
@@ -14,10 +14,6 @@ export type DependencyContext = {
     defaultTransportHandler: TransportHandler;
 };
 
-declare global {
-    var __qsMagellanDI__: DependencyContext;
-}
-
 export const initDependencyContext = (diContext: DependencyContext) => {
     global.__qsMagellanDI__ = diContext;
 };

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,8 +1,15 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "outDir": "./lib",
+        "outDir": "./lib"
     },
-    "exclude": ["node_modules", "src/**/*.spec.ts", "src/**/*.test.ts"],
-    "include": ["src/**/*.ts"]
+    "exclude": [
+        "node_modules",
+        "src/**/*.spec.ts",
+        "src/**/*.test.ts"
+    ],
+    "include": [
+        "src/**/*.ts",
+        "types"
+    ]
 }

--- a/packages/server/types/global.d.ts
+++ b/packages/server/types/global.d.ts
@@ -1,0 +1,10 @@
+/* eslint-disable no-var */
+import { DependencyContext } from "../src/services";
+import { Configuration } from "../src";
+
+export {};
+
+declare global {
+    var __qsMagellanServerConfig__: Configuration;
+    var __qsMagellanDI__: DependencyContext;
+}


### PR DESCRIPTION
This extracts the global defines into globa.d.ts files making them directly accessible to other packages, for example to consume in BDD tests in packages/tests.