### PR TITLE
Add support for magellan-client transport configuration runtime merge instead of replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ packages/test/test-source
 *.log
 *.iws
 .DS_Store
+tsconfig.tsbuildinfo
 .env.local
 .env.development.local
 .env.test.local

--- a/Release-Notes.md
+++ b/Release-Notes.md
@@ -14,6 +14,17 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.0.0/
 
 ### TBA
 
+## [0.3.0]
+
+### New Features
+
+- Support for `merge: true` in `@quatico/magellan-client/transport/config.js` to merge the configuration with the
+  existing configuration of a previous magellan-client frontend instead of replacing it.
+
+### Improvement
+
+- Updates @quatico/magellan-client documentation to current transport configuration.
+
 ## [0.2.2] - 2023-02-26
 
 ### Improvements

--- a/package.json
+++ b/package.json
@@ -1,81 +1,81 @@
 {
-  "name": "@quatico/magellan",
-  "description": "",
-  "version": "0.2.2",
-  "keywords": [
-    "typescript",
-    "java",
-    "compiler",
-    "addons"
-  ],
-  "private": true,
-  "author": "Quatico Solutions AG",
-  "license": "MIT",
-  "files": [
-    "LICENSE",
-    "README.md"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/quatico-solutions/magellan.git"
-  },
-  "bugs": {
-    "url": "https://github.com/quatico-solutions/magellan/issues"
-  },
-  "homepage": "https://github.com/quatico-solutions/magellan#readme",
-  "workspaces": {
-    "packages": [
-      "packages/*"
-    ]
-  },
-  "scripts": {
-    "clean": "nx run-many --target=clean",
-    "lint": "nx run-many --target=lint",
-    "lint:fix": "nx run-many --target=lint",
-    "build": "nx run-many --target=build",
-    "watch": "nx run-many --target=watch --parallel=10",
-    "test": "nx run-many --target=test",
-    "test:ci": "yarn jest --verbose && yarn --cwd packages/java test",
-    "test:watch": "nx run-many --target=test:watch --parallel=10",
-    "test:update": "nx run-many --target=test:update",
-    "test:e2e": "nx run-many --target=test:e2e",
-    "dist": "yarn clean && yarn lint && yarn test && cross-env-shell NODE_ENV=production \"yarn build\" && yarn test:e2e",
-    "prepare-release": "yarn dist && yarn lerna version --force-publish",
-    "prepare-prerelease": "yarn dist && yarn lerna version prerelease -y --force-publish",
-    "publish-npm": "lerna run --stream publish-npm",
-    "license:check": "license-check-and-add check -f license-config.json",
-    "license:add": "license-check-and-add add -f license-config.json",
-    "license:remove": "license-check-and-add remove -f license-config.json",
-    "prepare": "husky install"
-  },
-  "devDependencies": {
-    "@nrwl/nx-cloud": "latest",
-    "@swc/core": "^1.3.16",
-    "@swc/jest": "^0.2.23",
-    "cross-env": "^7.0.3",
-    "eslint": "^8.27.0",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-import-resolver-alias": "^1.1.2",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jest": "^27.1.5",
-    "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-testing-library": "^5.9.1",
-    "husky": "^8.0.2",
-    "jest": "^29.3.1",
-    "lerna": "6.1.x",
-    "license-check-and-add": "^4.0.5",
-    "lint-staged": "^13.0.3",
-    "memfs": "3.4.x",
-    "nx": "15.3.x",
-    "prettier": "^2.7.1",
-    "regenerator-runtime": "0.13.7",
-    "rimraf": "3.0.2",
-    "ts-jest": "^29.0.3",
-    "ts-node": "10.9.x",
-    "typescript": "4.7.x"
-  },
-  "engines": {
-    "node": ">=16.x",
-    "yarn": ">=1.22.x"
-  }
+    "name": "@quatico/magellan",
+    "description": "",
+    "version": "0.2.2",
+    "keywords": [
+        "typescript",
+        "java",
+        "compiler",
+        "addons"
+    ],
+    "private": true,
+    "author": "Quatico Solutions AG",
+    "license": "MIT",
+    "files": [
+        "LICENSE",
+        "README.md"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/quatico-solutions/magellan.git"
+    },
+    "bugs": {
+        "url": "https://github.com/quatico-solutions/magellan/issues"
+    },
+    "homepage": "https://github.com/quatico-solutions/magellan#readme",
+    "workspaces": {
+        "packages": [
+            "packages/*"
+        ]
+    },
+    "scripts": {
+        "clean": "nx run-many --target=clean",
+        "lint": "nx run-many --target=lint",
+        "lint:fix": "nx run-many --target=lint",
+        "build": "nx run-many --target=build",
+        "watch": "nx run-many --target=watch --parallel=10",
+        "test": "nx run-many --target=test",
+        "test:ci": "yarn jest --verbose && yarn --cwd packages/java test",
+        "test:watch": "nx run-many --target=test:watch --parallel=10",
+        "test:update": "nx run-many --target=test:update",
+        "test:e2e": "nx run-many --target=test:e2e",
+        "dist": "yarn clean --skip-nx-cache && yarn lint && yarn test --skip-nx-cache && cross-env-shell NODE_ENV=production \"yarn build\" --skip-nx-cache && yarn test:e2e --skip-nx-cache",
+        "prepare-release": "yarn dist && yarn lerna version --force-publish",
+        "prepare-prerelease": "yarn dist && yarn lerna version prerelease -y --force-publish",
+        "publish-npm": "lerna run --stream publish-npm",
+        "license:check": "license-check-and-add check -f license-config.json",
+        "license:add": "license-check-and-add add -f license-config.json",
+        "license:remove": "license-check-and-add remove -f license-config.json",
+        "prepare": "husky install"
+    },
+    "devDependencies": {
+        "@nrwl/nx-cloud": "latest",
+        "@swc/core": "^1.3.16",
+        "@swc/jest": "^0.2.23",
+        "cross-env": "^7.0.3",
+        "eslint": "^8.27.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jest": "^27.1.5",
+        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-testing-library": "^5.9.1",
+        "husky": "^8.0.2",
+        "jest": "^29.3.1",
+        "lerna": "6.1.x",
+        "license-check-and-add": "^4.0.5",
+        "lint-staged": "^13.0.3",
+        "memfs": "3.4.x",
+        "nx": "15.3.x",
+        "prettier": "^2.7.1",
+        "regenerator-runtime": "0.13.7",
+        "rimraf": "3.0.2",
+        "ts-jest": "^29.0.3",
+        "ts-node": "10.9.x",
+        "typescript": "4.7.x"
+    },
+    "engines": {
+        "node": ">=16.x",
+        "yarn": ">=1.22.x"
+    }
 }

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,33 +1,70 @@
 <!--
- ---------------------------------------------------------------------------------------------
-   Copyright (c) Quatico Solutions AG. All rights reserved.
-   Licensed under the MIT License. See LICENSE in the project root for license information.
+---------------------------------------------------------------------------------------------
+Copyright (c) Quatico Solutions AG. All rights reserved.
+Licensed under the MIT License. See LICENSE in the project root for license information.
  ---------------------------------------------------------------------------------------------
 -->
+
 ## Transport configuration
 
-Magellan uses the global.**qsMagellanConfig** object to access transport configurations.
+Magellan uses the global.**__qsMagellanConfig__** object to access transport configurations at runtime.
 
 ```json
 {
-    "host": "//localhost:3000",
-    "servicePath": "/api"
+    "namespaces": {
+        "default": {
+            "endpoint": "/api",
+            "transport": "default"
+        }
+    }
 }
 ```
 
-This configuration is injected to the window object by `@quatico/magellan-client/lib/configuration/config.js` which can be replaced during bundling with Webpack, for example for the Magellan AEM-Proxy running on the same machine serving the frontend:
+This configuration is injected to the window object by `@quatico/magellan-client/lib/transport/config.js` which can
+be replaced during bundling with Webpack to invoke a request against a `my-api` endpoint, merging its transport
+configuration if another magellan-client based frontend was already loaded previously.
 
 #### magellan.config.js
+
 ```javascript
+const createFormData = ({name, payload, namespace}) => {
+    const formData = new FormData();
+    formData.set("name", name);
+    formData.set("data", payload);
+    formData.set("namespace", namespace);
+    return formData;
+};
+
+// func is of type @quatico/magellan-client TransportFunction
+const myTransportFunction = async func => {
+    const {name, payload, namespace, endpoint} = func;
+    if (!name) {
+        throw new Error('Cannot invoke this remote function without "name" property.');
+    }
+    try {
+        const response = await fetch(endpoint, {
+            method: "POST",
+            body: createFormData({name, payload, namespace}),
+        });
+        return await response.text();
+    } catch (err) {
+        throw new Error(`Cannot invoke remote function: "${name}". Reason: "${err}".`);
+    }
+};
 module.exports = {
-    host: "",
-    servicePath: "/services/magellan/function"
-}
+    namespaces: {"test-namespace": {endpoint: "/my-api", transport: "my-transport"}},
+    transports: {"my-transport": myTransportFunction},
+    merge: true
+};
 ```
 
 #### webpack.config.js
+
 ```javascript
 plugins: [
-    new webpack.NormalModuleReplacementPlugin(/config.js/, join(__dirname, "magellan.config.js")),
-],
+    new webpack.NormalModuleReplacementPlugin(
+        /@quatico[\\/]magellan-client[\\/]lib[\\/]transport[\\/]config.js/,
+        path.join(__dirname, "magellan.config.js")
+    ),
+]
 ```

--- a/packages/client/src/transport/Configuration.ts
+++ b/packages/client/src/transport/Configuration.ts
@@ -9,4 +9,6 @@ import type { NamespaceMapping, TransportHandler } from "@quatico/magellan-share
 export type Configuration = {
     namespaces: Record<string, NamespaceMapping>;
     transports: Record<string, TransportHandler>;
+    lastMerged?: Configuration;
+    merge?: boolean;
 };

--- a/packages/client/src/transport/configuration-repository.spec.ts
+++ b/packages/client/src/transport/configuration-repository.spec.ts
@@ -7,10 +7,15 @@
 import { formdataFetch } from "./formdata-fetch";
 import { expandConfig, getConfiguration, initProjectConfiguration } from "./configuration-repository";
 import { getDefaultConfiguration } from "./default-configuration";
+import { Configuration } from "./Configuration";
+import config from "./config";
+
+jest.mock("./default-configuration");
 
 beforeEach(() => {
     // @ts-ignore
     global.__qsMagellanConfig__ = undefined;
+    jest.requireMock("./default-configuration").getDefaultConfiguration.mockReturnValue(config);
 });
 
 describe("initProjectConfiguration", () => {
@@ -30,7 +35,10 @@ describe("getDefaultConfig", () => {
     it("should return the minimal default configuration", () => {
         const actual = getDefaultConfiguration();
 
-        expect(actual).toEqual({ namespaces: { default: { endpoint: "/api", transport: "default" } }, transports: { default: formdataFetch } });
+        expect(actual).toEqual({
+            namespaces: { default: { endpoint: "/api", transport: "default" } },
+            transports: { default: formdataFetch },
+        });
     });
 });
 
@@ -40,6 +48,27 @@ describe("getConfiguration", () => {
 
         const actual = getConfiguration();
 
+        // We are not interested in lastMerged
+        delete actual.lastMerged;
+        expect(actual).toEqual(expected);
+    });
+
+    it("should return a merged default configuration with a config.js different from global.__qsMagellanConfig__", () => {
+        const preexistingConfig = <Configuration>{
+            namespaces: { original: { endpoint: "/expected", transport: "default" } },
+            transports: { default: formdataFetch },
+            merge: true,
+        };
+        jest.requireMock("./default-configuration").getDefaultConfiguration.mockReturnValue(preexistingConfig);
+        global.__qsMagellanConfig__ = config;
+        const expected: Configuration = {
+            namespaces: { ...config.namespaces, ...preexistingConfig.namespaces },
+            transports: { default: formdataFetch },
+        };
+
+        const actual = getConfiguration();
+
+        delete actual.lastMerged;
         expect(actual).toEqual(expected);
     });
 });
@@ -48,20 +77,29 @@ describe("expandConfig", () => {
     it("should expand config w/ missing transport", () => {
         const actual = expandConfig({ namespaces: { default: { endpoint: "/expected" } } });
 
-        expect(actual).toEqual({ namespaces: { default: { endpoint: "/expected", transport: "default" } }, transports: { default: formdataFetch } });
+        expect(actual).toEqual({
+            namespaces: { default: { endpoint: "/expected", transport: "default" } },
+            transports: { default: formdataFetch },
+        });
     });
 
     it("should expand config w/ missing namespace", () => {
         const actual = expandConfig({ transports: { default: formdataFetch } });
 
-        expect(actual).toEqual({ namespaces: { default: { endpoint: "/api", transport: "default" } }, transports: { default: formdataFetch } });
+        expect(actual).toEqual({
+            namespaces: { default: { endpoint: "/api", transport: "default" } },
+            transports: { default: formdataFetch },
+        });
     });
 
     it("should add default configuration w/ a non-default configuration", () => {
         const actual = expandConfig({ namespaces: { fun: { endpoint: "/fun" } } });
 
         expect(actual).toEqual({
-            namespaces: { default: { endpoint: "/api", transport: "default" }, fun: { endpoint: "/fun", transport: "default" } },
+            namespaces: {
+                default: { endpoint: "/api", transport: "default" },
+                fun: { endpoint: "/fun", transport: "default" },
+            },
             transports: { default: formdataFetch },
         });
     });

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,7 +1,12 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "outDir": "./lib"
+        "outDir": "./lib",
+        "paths": {
+            "@quatico/magellan-shared/*": [
+                "../shared/src/*"
+            ]
+        }
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Implements an optional capability to enable the merge of transport configurations of @quatico/magellan-client and uses the opportunity to update the corresponding README.

---
Depends on https://github.com/quatico-solutions/magellan/pull/39 to be merged first.